### PR TITLE
Clouding automatic hashing Workround

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,6 +95,7 @@ Adapter.prototype.save = function(name, email, pw, done) {
               user = {
                   name: name,
                   password_scheme: 'pbkdf2',
+                  email: email,
                   derived_key: hash,
                   salt: saltRandom,
                   roles: ['user'],

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "moment": "^2.8.1",
     "ms": "^0.7.1",
     "nano": "^6.1.4",
-    "node-uuid": "~1.4.1"
+    "node-uuid": "~1.4.1",
+    "couch-pwd": "0.0.1"
   },
   "devDependencies": {
     "eslint": "^0.24.0",


### PR DESCRIPTION
The Clouding services, actually does not support the automatic hashing
of user password, so its necessary to create the hash before save the
user on DB, so I created this workaround.
*Improvement: use the Bluebird to handle the async pwd function and to
write a clear code.

To make it work is necessary to customize the config as showed below:
exports.db ={
    service: 'cloudant'
  };

close #9 
